### PR TITLE
Add secret scanning precommit hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'  # Use a specific Python version, e.g., '3.9'
+          python-version: '3.x'
 
       - name: Install dependencies
         run: |
@@ -22,4 +22,4 @@ jobs:
           pip install pre-commit
 
       - name: Run pre-commit hooks
-        run: pre-commit run --all-files
+        run: make precommit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,5 +21,11 @@ repos:
       - id: isort
         args: ["--profile", "black"]
 
+  # Detect secrets in the codebase
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: install precommit
+
+install:
+	pip install pre-commit
+	pre-commit install
+
+precommit:
+	pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # devops-tooling
 Tools I have automated or custom built for various devops tasks.
+
+## Development
+
+Use the provided `Makefile` to install and run pre-commit hooks:
+
+```bash
+$ make install   # install pre-commit and set up git hooks
+$ make precommit # run all pre-commit hooks
+```


### PR DESCRIPTION
## Summary
- add detect-secrets hook to `.pre-commit-config.yaml`
- install pre-commit via `Makefile` and run precommit checks
- update GitHub Actions workflow to use `make precommit`
- document usage in `README.md`

## Testing
- `make precommit` *(fails: pre-commit not installed)*
- `make install` *(fails: could not install pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68418dc719d4832fb1129f26a78ef64c