### PR TITLE
Add Docker setup playbook

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,3 +1,22 @@
 # Ansible Tooling
 
 This directory contains scripts and playbooks for managing infrastructure with Ansible.
+
+## Structure
+
+- `playbooks/` - entry point playbooks.
+- `tasks/<os>/` - OS specific task snippets that can be reused by playbooks.
+
+Currently only Ubuntu Docker installation tasks are provided, but additional
+operating system directories can be added under `tasks/` in the future.
+
+## Example
+
+Run the Docker setup playbook against your inventory:
+
+```bash
+ansible-playbook playbooks/docker.yml -i hosts
+```
+
+Ensure that your inventory group or host variables correctly identify the
+operating system so the playbook can include the appropriate task file.

--- a/ansible/playbooks/docker.yml
+++ b/ansible/playbooks/docker.yml
@@ -1,0 +1,7 @@
+---
+- name: Install Docker
+  hosts: all
+  become: true
+  tasks:
+    - name: Include OS specific tasks
+      ansible.builtin.include_tasks: "../tasks/{{ ansible_distribution | lower }}/docker.yml"

--- a/ansible/tasks/ubuntu/docker.yml
+++ b/ansible/tasks/ubuntu/docker.yml
@@ -1,0 +1,39 @@
+---
+# Install Docker on Ubuntu
+
+- name: Install required packages
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - software-properties-common
+    state: present
+    update_cache: yes
+
+- name: Add Docker GPG key
+  ansible.builtin.apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    state: present
+    update_cache: yes
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+    state: present
+    update_cache: yes
+
+- name: Ensure Docker is running
+  ansible.builtin.service:
+    name: docker
+    state: started
+    enabled: yes


### PR DESCRIPTION
## Summary
- add a playbook that installs Docker
- create OS specific task file for Ubuntu
- document ansible folder structure

## Testing
- `make install` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `make precommit` *(fails: pre-commit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684196e8b2dc832f8befc35fefbda9b7