### PR TITLE
Add Ansible inventory and dynamic variables

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -6,6 +6,8 @@ This directory contains scripts and playbooks for managing infrastructure with A
 
 - `playbooks/` - entry point playbooks.
 - `tasks/<os>/` - OS specific task snippets that can be reused by playbooks.
+- `group_vars/` - default variables consumed by the task snippets.
+- `hosts` - example inventory file for running the playbooks locally.
 
 Currently only Ubuntu Docker installation tasks are provided, but additional
 operating system directories can be added under `tasks/` in the future.
@@ -19,4 +21,6 @@ ansible-playbook playbooks/docker.yml -i hosts
 ```
 
 Ensure that your inventory group or host variables correctly identify the
-operating system so the playbook can include the appropriate task file.
+operating system so the playbook can include the appropriate task file. All
+variables used by the Docker role are defined in `group_vars/all.yml` so they
+can be easily overridden per environment.

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,0 +1,25 @@
+# Global Ansible variables for Docker installation
+
+# Packages required before installing Docker
+docker_prereq_packages:
+  - apt-transport-https
+  - ca-certificates
+  - curl
+  - gnupg
+  - software-properties-common
+
+# GPG key URL used to verify Docker packages
+docker_gpg_key_url: https://download.docker.com/linux/ubuntu/gpg
+
+# Repository base URL and architecture for Docker packages
+docker_repo_url: https://download.docker.com/linux/ubuntu
+docker_repo_arch: amd64
+# Use the detected distribution release by default
+docker_repo_release: "{{ ansible_distribution_release }}"
+
+docker_packages:
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+
+docker_service_name: docker

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,0 +1,2 @@
+[ubuntu]
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3

--- a/ansible/tasks/ubuntu/docker.yml
+++ b/ansible/tasks/ubuntu/docker.yml
@@ -3,37 +3,29 @@
 
 - name: Install required packages
   ansible.builtin.apt:
-    name:
-      - apt-transport-https
-      - ca-certificates
-      - curl
-      - gnupg
-      - software-properties-common
+    name: "{{ docker_prereq_packages }}"
     state: present
     update_cache: yes
 
 - name: Add Docker GPG key
   ansible.builtin.apt_key:
-    url: https://download.docker.com/linux/ubuntu/gpg
+    url: "{{ docker_gpg_key_url }}"
     state: present
 
 - name: Add Docker repository
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    repo: "deb [arch={{ docker_repo_arch }}] {{ docker_repo_url }} {{ docker_repo_release }} stable"
     state: present
     update_cache: yes
 
 - name: Install Docker packages
   ansible.builtin.apt:
-    name:
-      - docker-ce
-      - docker-ce-cli
-      - containerd.io
+    name: "{{ docker_packages }}"
     state: present
     update_cache: yes
 
 - name: Ensure Docker is running
   ansible.builtin.service:
-    name: docker
+    name: "{{ docker_service_name }}"
     state: started
     enabled: yes


### PR DESCRIPTION
## Summary
- add example inventory and global group variables
- reference variables in Ubuntu Docker tasks
- document new locations in Ansible README

## Testing
- `make install` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `make precommit` *(fails: pre-commit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684197eceed0832fb41518f9115cd517