### PR TITLE
Update bootstrap_ansible script README generation

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -1,14 +1,14 @@
 # Setup Tooling
 
-This directory contains helper scripts for bootstrapping new infrastructure
-projects.
+This directory contains helper scripts for bootstrapping new infrastructure projects.
 
 ## bootstrap_ansible.sh
 
-Creates a minimal Ansible project layout. Provide a target directory as the
-only argument and the script will create common folders and documentation
-placeholders.
+Creates a minimal Ansible project layout complete with a sample playbook, inventory, and variable files. Provide a target directory as the only argument and the script will populate it with a recommended structure and a detailed README.
 
 ```bash
 ./bootstrap_ansible.sh my-ansible-project
 ```
+
+The generated README explains how to run the example playbook, how to use tags, and where to place host or group variables for customization.
+

--- a/setup/bootstrap_ansible.sh
+++ b/setup/bootstrap_ansible.sh
@@ -21,19 +21,85 @@ cat > "$root_dir/inventory/hosts" <<'INV'
 localhost ansible_connection=local
 INV
 
-# Basic README template
+# Sample group vars
+cat > "$root_dir/group_vars/all.yml" <<'VARS'
+---
+# Global variables
+package_state: present
+VARS
+
+# Sample host vars
+cat > "$root_dir/host_vars/localhost.yml" <<'VARS'
+---
+# Host specific variables
+my_host_var: default_value
+VARS
+
+# Sample role
+mkdir -p "$root_dir/roles/sample_role/tasks"
+cat > "$root_dir/roles/sample_role/tasks/main.yml" <<'ROLE'
+---
+- name: Echo a message
+  ansible.builtin.debug:
+    msg: "Sample role executed"
+ROLE
+
+# Sample playbook demonstrating tags
+cat > "$root_dir/playbooks/site.yml" <<'PLAY'
+---
+- name: Example play
+  hosts: all
+  roles:
+    - role: sample_role
+      tags: ["setup"]
+PLAY
+
+# Detailed README
 cat > "$root_dir/README.md" <<'EOF_MD'
 # Ansible Project
 
-This directory was bootstrapped by the setup tooling script. It provides a
-minimal best‑practice layout for new Ansible automation work.
+This directory was bootstrapped by the setup tooling script. It provides a minimal best-practice layout for new Ansible automation work.
+
+## Layout
 
 - `playbooks/` – entry point playbooks
-- `group_vars/` – group variable files
-- `host_vars/` – host variable files
 - `roles/` – reusable roles
+- `group_vars/` – shared variables for all hosts
+- `host_vars/` – host specific variables
 - `inventory/` – default inventory location
 - `docs/` – project documentation
+
+## Usage
+
+Run the sample playbook against the provided inventory:
+
+```bash
+ansible-playbook playbooks/site.yml -i inventory/hosts
+```
+
+To run only tasks tagged `setup`:
+
+```bash
+ansible-playbook playbooks/site.yml -i inventory/hosts --tags setup
+```
+
+## Inventory
+
+Edit `inventory/hosts` to define your hosts. The default content is:
+
+```ini
+[example]
+localhost ansible_connection=local
+```
+
+## Variable files
+
+- `group_vars/all.yml` contains global variables such as `package_state`.
+- `host_vars/localhost.yml` holds host-specific settings like `my_host_var`.
+
+## Tags
+
+The sample playbook assigns the tag `setup` to the `sample_role`. Tags let you run only portions of a playbook with `--tags` or skip them with `--skip-tags`.
 EOF_MD
 
 # Documentation placeholder
@@ -44,3 +110,4 @@ Describe how to use this Ansible project here.
 DOC
 
 printf '\nAnsible project created at %s\n' "$root_dir"
+


### PR DESCRIPTION
## Summary
- expand the bootstrap script to create example playbook, role and vars
- generate a detailed README explaining usage and tags
- document script behavior in setup README

## Testing
- `make precommit` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846a1bbf230832fbf0a67b5dfc81881